### PR TITLE
Add support for multiple keywords with 'or' and 'not' operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ his project is a test of application implementation for [Trevari](https://m.trev
     }
     ```
     - [X] Implement infinite scrolling.
-    - [ ] Allow users to enter specific keywords. Keywords can be up to two and are separated by the "or" and "not" operators.
-        - [ ] The "or(|)" operator displays the results of the search for each keyword. (e.g. "tdd|javascript": the results of the search for tdd and the results of the search for javascript are combined.)
-        - [ ] The "not(-)" operator searches for books that contain the previous keyword in the title, but do not contain the following keyword. (e.g. "tdd-javascript": searches for books that contain the tdd keyword in the title, but do not contain the javascript keyword.)
+    - [X] Allow users to enter specific keywords. Keywords can be up to two and are separated by the "or" and "not" operators.
+        - The "or(|)" operator displays the results of the search for each keyword. (e.g. "tdd|javascript": the results of the search for tdd and the results of the search for javascript are combined.)
+        - The "not(-)" operator searches for books that contain the previous keyword in the title, but do not contain the following keyword. (e.g. "tdd-javascript": searches for books that contain the tdd keyword in the title, but do not contain the javascript keyword.)
     
     b. [Detail]: Displays the detailed information of the selected book from the book list.
     - [X] The following properties must be displayed on the screen from the data received in JSON.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test": "jest"
+    "test": "jest --watchAll"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/src/apis/BookList.api.ts
+++ b/src/apis/BookList.api.ts
@@ -15,15 +15,14 @@ export class BookList {
 
     static getInstance(request: BookAPIRequest) {
         if(!BookList.instance) {
-            return new BookList(request);
+            this.instance = new BookList(request);
         }
 
         return this.instance;
     }
 
-    async getBookList<T>(keyword: string, pageNumber?: string): Promise<T[]> {
-        const baseUrl = `https://api.itbook.store/1.0/search/${keyword}`;
-        const bookListUrl = (pageNumber) ? `${baseUrl}/${pageNumber}`: baseUrl;
+    async getBookList<T>(keyword: string, pageNumber: string): Promise<T[]> {
+        const bookListUrl = `https://api.itbook.store/1.0/search/${keyword}/${pageNumber}`;
 
         const response = await this.request.get(bookListUrl);
         const data:APIResponse<T> = await response.json();

--- a/src/tests/BookList.test.ts
+++ b/src/tests/BookList.test.ts
@@ -7,36 +7,44 @@ test("search book list [keywords: mongodb]", async () => {
   const bookTestApiRequest = BookAPIRequest.of(new FetchTestAPI());
   const mongodbBooks = await BookList.getInstance(
     bookTestApiRequest
-  ).getBookList<Book>("mongodb");
+  ).getBookList<Book>("mongodb", "1");
 
   expect(mongodbBooks.length > 0).toBe(true);
 });
 
 test("search book list empty keyword throw error", async () => {
   const bookTestApiRequest = BookAPIRequest.of(new FetchTestAPI());
+  const empty = await BookList.getInstance(
+    bookTestApiRequest
+  ).getBookList<Book>("", "1");
 
-  await expect(async () => {
-    await BookList.getInstance(bookTestApiRequest).getBookList<Book>("");
-  }).rejects.toThrowError(new Error("[search] Invalid request"));
+  expect(empty.length).toBe(0);
 });
 
 test("mongodb book page one and page two list not equal", async () => {
   const bookTestApiRequest = BookAPIRequest.of(new FetchTestAPI());
-  const bookListInstance = BookList.getInstance(
-    bookTestApiRequest
+  const bookListInstance = BookList.getInstance(bookTestApiRequest);
+  const mongodbBooksPageOne = await bookListInstance.getBookList<Book>(
+    "mongodb",
+    "1"
   );
-  const mongodbBooksPageOne = await bookListInstance.getBookList<Book>("mongodb", "1");
-  const mongodbBooksPageTwo = await bookListInstance.getBookList<Book>("mongodb", "2");
+  const mongodbBooksPageTwo = await bookListInstance.getBookList<Book>(
+    "mongodb",
+    "2"
+  );
 
-  expect(mongodbBooksPageOne[0].isbn13).not.toEqual(mongodbBooksPageTwo[0].isbn13);
+  expect(mongodbBooksPageOne[0].isbn13).not.toEqual(
+    mongodbBooksPageTwo[0].isbn13
+  );
 });
 
 test("mongodb book last page is empty", async () => {
   const bookTestApiRequest = BookAPIRequest.of(new FetchTestAPI());
-  const bookListInstance = BookList.getInstance(
-    bookTestApiRequest
+  const bookListInstance = BookList.getInstance(bookTestApiRequest);
+  const mongodbBooksLastPage = await bookListInstance.getBookList<Book>(
+    "mongodb",
+    "9"
   );
-  const mongodbBooksLastPage = await bookListInstance.getBookList<Book>("mongodb", "9");
 
   expect(mongodbBooksLastPage.length).toBe(0);
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    sourcemap: true,
+  }
 })


### PR DESCRIPTION
Allow users to enter specific keywords. Keywords can be up to two and are separated by the "or" and "not" operators.